### PR TITLE
Replace Adorable with Gravatar

### DIFF
--- a/demo/forum/templates/forum/thread.html
+++ b/demo/forum/templates/forum/thread.html
@@ -6,7 +6,7 @@
   {% for comment in thread.comment_set.all %}
   <div class="event">
     <div class="label">
-      <img src="https://api.adorable.io/avatars/{{ comment.user.id}}" />
+      <img src="https://www.gravatar.com/avatar/{{ comment.user.id }}/?d=monsterid" />
     </div>
     <div class="content">
       <div class="summary">


### PR DESCRIPTION
Seems like the Adorable API is no longer functioning. A nice and simple replace can be Gravatar.

This creates random images using the "mosterid" replace icon generator.
https://en.gravatar.com/site/implement/images/

<img width="658" alt="Screenshot 2023-03-29 at 23 10 04" src="https://user-images.githubusercontent.com/4421882/228668207-09841c45-f078-417f-9744-be5c4c79c50c.png">
